### PR TITLE
Do not install tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,11 @@ install_requires =
 setup_requires =
     setuptools_scm
 
+[options.packages.find]
+exclude =
+    test
+    test.*
+
 [options.extras_require]
 dev =
     responses


### PR DESCRIPTION
Installing tests is generally not necessary or desirable in the first place, but particularly not in the global top level `test` package.

`test.*` is to catch possible subpackages added in the future.